### PR TITLE
Fix out-of-bounds read in FillInParameterName

### DIFF
--- a/include/AudioUnitSDK/AUBase.h
+++ b/include/AudioUnitSDK/AUBase.h
@@ -510,7 +510,7 @@ protected:
 		if (inShouldRelease) {
 			ioInfo.flags |= kAudioUnitParameterFlag_CFNameRelease;
 		}
-		CFStringGetCString(inName, &ioInfo.name[0], offsetof(AudioUnitParameterInfo, clumpID),
+		CFStringGetCString(inName, std::data(ioInfo.name), std::size(ioInfo.name),
 			kCFStringEncodingUTF8);
 	}
 


### PR DESCRIPTION
- [x] I understand that response time may be limited because the project doesn't accept pull requests.
- [x] I agree to the terms outlined in CONTRIBUTING.md 

This change fixes a potential out-of-bounds read by CFStringGetCString. `offsetof(..., clumpID` is not the correct buffer size for `name`, because the definition of `AudioUnitParameterInfo` includes an extra field, `unitName`, between `name` and `clumpID`. Additionally, the compiler may choose to insert padding after `name` in order to ensure the correct alignment of the following struct member.

```c++
struct AudioUnitParameterInfo {
	char name[52];
	CFStringRef __nullable unitName;
	UInt32 clumpID;
	...
```