### PR TITLE
wrap Expected value macro bodies in parentheses

### DIFF
--- a/include/AudioUnitSDK/AUUtility.h
+++ b/include/AudioUnitSDK/AUUtility.h
@@ -77,21 +77,21 @@
 // Evaluate an expression resulting in an Expected<T>. If the Expected contains an error, return
 // the error. Otherwise, unwrap the Expected.
 #define AUSDK_UnwrapOrReturnError(_expression)                                                     \
-	*({                                                                                            \
+	(*({                                                                                           \
 		const auto e = (_expression);                                                              \
 		if (!e) [[unlikely]]                                                                       \
 			return e.error();                                                                      \
 		e;                                                                                         \
-	})
+	}))
 
 // TODO: deprecate this macro because it swallows the error
 #define AUSDK_UnwrapOrReturnVoid(_expression)                                                      \
-	*({                                                                                            \
+	(*({                                                                                           \
 		const auto e = (_expression);                                                              \
 		if (!e) [[unlikely]]                                                                       \
 			return;                                                                                \
 		e;                                                                                         \
-	})
+	}))
 
 #define AUSDK_CheckReturnError(_expression)                                                        \
 	({                                                                                             \
@@ -103,12 +103,12 @@
 // Evaluate an expression resulting in an Expected<T>. If the Expected contains an error, return
 // the error as an Unexpected. Otherwise, unwrap the Expected.
 #define AUSDK_UnwrapOrReturnUnexpected(_expression)                                                \
-	*({                                                                                            \
+	(*({                                                                                           \
 		const auto e = (_expression);                                                              \
 		if (!e) [[unlikely]]                                                                       \
 			return ausdk::Unexpected{ e.error() };                                                 \
 		e;                                                                                         \
-	})
+	}))
 
 #define AUSDK_Require_noerr(_expression) /* NOLINT(cppcoreguidelines-macro-usage) */               \
 	do {                                                                                           \


### PR DESCRIPTION
The `Expected` value macros `AUSDK_UnwrapOrReturnError`,  `AUSDK_UnwrapOrReturnVoid`, and `AUSDK_UnwrapOrReturnUnexpected ` aren't well encapsulated with parentheses around their bodies, making them unusable in expressions dereferencing the value results, e.g.:

`AUSDK_UnwrapOrReturnError(GetOutput0().GetBufferListOrError()).mNumberBuffers;`

reduced error messages:
```
error: no member named 'mNumberBuffers' in 'ausdk::ExpectedPtr<AudioBufferList>'; did you mean to use '->' instead of '.'?
 1656 |         AUSDK_UnwrapOrReturnError(theOutput.GetBufferListOrError()).mNumberBuffers;
      |                                                                                                  ^
      |                                                                                                  ->
error: indirection requires pointer operand ('UInt32' (aka 'unsigned int') invalid)
 1656 |         AUSDK_UnwrapOrReturnError(theOutput.GetBufferListOrError()).mNumberBuffers;
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
AudioUnitSDK/include/AudioUnitSDK/AUUtility.h:80:2: note: expanded from macro 'AUSDK_UnwrapOrReturnError'
   80 |         *({                                                                                           \
      |         ^
```

- [X ] I understand that response time may be limited because the project doesn't accept pull requests.
- [ X] I agree to the terms outlined in CONTRIBUTING.md 
